### PR TITLE
Added instruction to tap formula command before install

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Heroku Homebrew Tap
 
 Install the Heroku CLI with
 
+    $ brew tap heroku/brew
     $ brew install heroku/brew/heroku
 
 For more information, visit https://cli.heroku.com


### PR DESCRIPTION
Pull request to add tap command before the install command based upon my experience attempting to install with Homebrew v.2.0.0 .

![screenshot 2019-02-03 12 07 30](https://user-images.githubusercontent.com/367712/52179770-57a80c80-27ac-11e9-9617-3cfb06d98850.png)
