### PR TITLE
Automatically refresh the autocomplete cache

### DIFF
--- a/Formula/heroku.rb
+++ b/Formula/heroku.rb
@@ -14,6 +14,10 @@ class Heroku < Formula
     bash_completion.install "#{libexec}/node_modules/@heroku-cli/plugin-autocomplete/autocomplete/brew/bash"
     zsh_completion.install "#{libexec}/node_modules/@heroku-cli/plugin-autocomplete/autocomplete/brew/zsh/_heroku"
   end
+  
+  def post_install
+    system "heroku", "autocomplete", "--refresh-cache"
+  end
 
   def caveats; <<~EOS
     To use the Heroku CLI's autocomplete --


### PR DESCRIPTION
Is there any reason _not_ to just automatically refresh the autocomplete cache instead of mentioning that it's necessary in the caveats?

- [ ] remove the corresponding caveat message
- [ ] confirm what happens for users that don't have bash-completion installed