### PR TITLE
Rename bash completion script as `heroku`

### DIFF
--- a/Formula/heroku.rb
+++ b/Formula/heroku.rb
@@ -7,12 +7,12 @@ class Heroku < Formula
 
   def install
     inreplace "bin/heroku", /^CLIENT_HOME=/, "export HEROKU_OCLIF_CLIENT_HOME=#{lib/"client"}\nCLIENT_HOME="
-    inreplace "bin/heroku", "\"$DIR/node\"", "#{Formula["heroku-node"].opt_share}/node"
+    inreplace "bin/heroku", "\"$DIR/node\"", Formula["heroku-node"].opt_share/"node"
     libexec.install Dir["*"]
     bin.install_symlink libexec/"bin/heroku"
 
-    bash_completion.install "#{libexec}/node_modules/@heroku-cli/plugin-autocomplete/autocomplete/brew/bash"
-    zsh_completion.install "#{libexec}/node_modules/@heroku-cli/plugin-autocomplete/autocomplete/brew/zsh/_heroku"
+    bash_completion.install libexec/"node_modules/@heroku-cli/plugin-autocomplete/autocomplete/brew/bash"
+    zsh_completion.install libexec/"node_modules/@heroku-cli/plugin-autocomplete/autocomplete/brew/zsh/_heroku"
   end
 
   def caveats; <<~EOS

--- a/Formula/heroku.rb
+++ b/Formula/heroku.rb
@@ -11,7 +11,7 @@ class Heroku < Formula
     libexec.install Dir["*"]
     bin.install_symlink libexec/"bin/heroku"
 
-    bash_completion.install libexec/"node_modules/@heroku-cli/plugin-autocomplete/autocomplete/brew/bash"
+    bash_completion.install libexec/"node_modules/@heroku-cli/plugin-autocomplete/autocomplete/brew/bash" => "heroku"
     zsh_completion.install libexec/"node_modules/@heroku-cli/plugin-autocomplete/autocomplete/brew/zsh/_heroku"
   end
 


### PR DESCRIPTION
The `install` command accepts a hash in addition to a string. As a hash, the keys are the files to install, the values are the names to use when installed.

The _cleaner_ implementation here would be to update the actual script filenames within the autocomplete package itself. (There's some jarring inconsistency here where brew/bash is a script, while brew/zsh is a _directory_ that contains the script.)

Ideally, I'd probably expect the brew/bash file to be renamed as `brew/bash/heroku` and that would eliminate the need for this hash syntax. However, simply changing the Formula is probably easier.

(Also, this updates the formula to use homebrew's path helpers consistently.

Closes #16 