### PR TITLE
chore: Add @heroku/frontend-dev-tooling to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,5 +2,5 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-* @heroku/front-end
+* @heroku/front-end @heroku/frontend-dev-tooling
 #ECCN:Open Source

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,5 +2,9 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-* @heroku/front-end @heroku/frontend-dev-tooling
+# Comment line immediately above ownership line is reserved for related GUS information.
+# Please exercise caution while editing.
+
+#GUSINFO: Heroku FE Dev Tools,Heroku CLI & Plugins
+* @heroku/frontend-dev-tooling @heroku/front-end
 #ECCN:Open Source

--- a/scripts/test
+++ b/scripts/test
@@ -3,6 +3,19 @@
 set -ex
 
 brew update
-brew install Formula/heroku.rb
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Force untap if already tapped to avoid remote mismatch conflicts
+brew untap --force heroku/brew 2>/dev/null || true
+
+# Tap the local repository as heroku/brew
+brew tap heroku/brew "$REPO_DIR"
+
+# Install from the tap
+brew install heroku/brew/heroku
+
 heroku version
 heroku help


### PR DESCRIPTION
## Summary

Add `@heroku/frontend-dev-tooling` team to CODEOWNERS file to ensure proper code review coverage.

## Changes

- Added `@heroku/frontend-dev-tooling` as a code owner alongside existing teams
- Fixes an error with installing the formula from a local tap

## Context

This aligns the CODEOWNERS with the `team:developer-tooling` custom property and ensures the Developer Tooling team is notified for PR reviews.

---
*Automated update as part of team repository reconciliation.*